### PR TITLE
use continuous-local-storage instead of passing request

### DIFF
--- a/coluutils.js
+++ b/coluutils.js
@@ -12,7 +12,7 @@ module.exports = (function () {
     var assetIdencoder = require('cc-assetid-encoder')
     var _ = require('lodash')
     var rsa = require('node-rsa')
-    var session = require('continuation-local-storage').getNamespace('coloredcoinsd')
+    var session = require('continuation-local-storage').getNamespace(config.serverName)
     var findBestMatchByNeededAssets = require('./modules/findBestMatchByNeededAssets')
 
     

--- a/config.js
+++ b/config.js
@@ -1,6 +1,7 @@
 var config = {
   env: 'development',
   testnet: true,
+  serverName: 'coloredcoinsd',
   google_api_key: 'AIzaSyBJfxobLSO_IM9tI1ATWpOelVInNuH1kBM',
   machineurl: 'http://api.coloredcoins.org',
   useS3: true,
@@ -32,7 +33,8 @@ var config = {
   mindustvalue: 600,
   mindustvaluemultisig: 700,
   feePerKb: 1000,
-  checkFinanaceValidty: true
+  checkFinanaceValidty: true,
+  secret: 'secret'
 }
 
 
@@ -57,6 +59,7 @@ if (module_exists('./config-local')) {
   config.bitcoind.path = process.env.BITCOIND_PATH || config.bitcoind.path
   config.torrentServer.url = process.env.TORRENT_SERVER_URL || config.torrentServer.url
   config.testnet = process.env.TESTNET || config.testnet
+  config.serverName = process.env.SERVERNAME || config.serverName
   config.torrentServer.token = process.env.TORRENT_SERVER_TOKEN || config.torrentServer.token
   config.minfee = parseInt(process.env.MINFEE || '' + config.minfee, 10)
   config.mindustvalue = parseInt(process.env.MINDUSTVALUE || '' + config.mindustvalue, 10)
@@ -70,6 +73,6 @@ if (module_exists('./config-local')) {
   config.piwik.version_dim_id = process.env.PIWIK_VERSION_DIM_ID || config.piwik.version_dim_id
   config.piwik.debug = process.env.PIWIK_DEBUG || false
   config.piwik.enabled = config.piwik.url && config.piwik.token && config.piwik.siteid
-  config.secret = process.env.SECRET
+  config.secret = process.env.SECRET || config.secret
   module.exports = config
 }

--- a/config.js
+++ b/config.js
@@ -33,8 +33,7 @@ var config = {
   mindustvalue: 600,
   mindustvaluemultisig: 700,
   feePerKb: 1000,
-  checkFinanaceValidty: true,
-  secret: 'secret'
+  checkFinanaceValidty: true
 }
 
 
@@ -73,6 +72,6 @@ if (module_exists('./config-local')) {
   config.piwik.version_dim_id = process.env.PIWIK_VERSION_DIM_ID || config.piwik.version_dim_id
   config.piwik.debug = process.env.PIWIK_DEBUG || false
   config.piwik.enabled = config.piwik.url && config.piwik.token && config.piwik.siteid
-  config.secret = process.env.SECRET || config.secret
+  config.secret = process.env.SECRET
   module.exports = config
 }

--- a/controllers/v2/color.js
+++ b/controllers/v2/color.js
@@ -113,9 +113,8 @@ module.exports = (function () {
             },
             'action': function (req, res, next) {
                 var verbosity = parseInt(req.query.verbosity)
-                var headersToForward = req.service && req.service.headersToForward
                 verbosity = ([0,1].indexOf(verbosity) > -1)? verbosity : 1
-                api.getAssetMetadata(req.params.assetId, req.params.utxo, verbosity, headersToForward).
+                api.getAssetMetadata(req.params.assetId, req.params.utxo, verbosity).
                 then(
                     function(data) { res.status(200).send(data) }, 
                     next
@@ -142,7 +141,7 @@ module.exports = (function () {
                 "nickname": "getAddressInfo"
             },
             'action': function (req, res, next) {
-              api.getAddressInfo(req.params.address, req.service && req.service.headersToForward).
+              api.getAddressInfo(req.params.address).
               then(function (data) {
                 var jsondata = api.safeParse(data)
                 res.status(200).send(Array.isArray(req.params.address) ? jsondata : jsondata[0])
@@ -184,11 +183,10 @@ module.exports = (function () {
 
     function tryBroadcastAsset(req, res, next) {
         console.log("tryBroadcastAsset")
-        var headersToForward = req.service && req.service.headersToForward
 
-        api.broadcastTx(req.body.txHex, headersToForward).
+        api.broadcastTx(req.body.txHex).
         then(function(txid){
-            api.requestParseTx(txid, headersToForward);
+            api.requestParseTx(txid);
             res.status(200).send({txid: txid});
         }).
         catch(next).done();
@@ -202,9 +200,7 @@ module.exports = (function () {
         validateInput(req.body).
         then(checkParameters).
         then(api.uploadMetadata).
-        then(function (metadata) {
-          return api.createIssueTransaction(metadata, req.service && req.service.headersToForward)
-        }).
+        then(api.createIssueTransaction).
         then(function(data) {
           api.seedMetadata(data.metadata.sha1)
           var response = {txHex: data.txHex, assetId: data.assetId, coloredOutputIndexes: data.coloredOutputIndexes }
@@ -288,9 +284,7 @@ module.exports = (function () {
             validateInput(req.body, null, ['from', 'sendutxo']).
             then(checkParameters).
             then(api.uploadMetadata).
-            then(function (data) {
-              return api.createSendAssetTansaction(data, req.service && req.service.headersToForward)
-            }).
+            then(api.createSendAssetTansaction).
             then(function(data) {
                  api.seedMetadata(data.metadata.sha1);
                  res.json({ txHex: data.tx.toHex(), metadataSha1: data.metadata.sha1, multisigOutputs: data.multisigOutputs });
@@ -304,7 +298,7 @@ module.exports = (function () {
 
     function trygetAssetStakeholders(req, res, next) {
         try{
-            api.getAssetStakeholders(req.params.assetId, req.params.numConfirmations, req.service.headersToForward)
+            api.getAssetStakeholders(req.params.assetId, req.params.numConfirmations)
             .then(function(data) {             
                  res.json(data);
             })

--- a/controllers/v3/color.js
+++ b/controllers/v3/color.js
@@ -163,9 +163,7 @@ module.exports = (function () {
             validateInput(req.body, null, ['from', 'sendutxo']).
             then(checkParameters).
             then(api.uploadMetadata).
-            then(function (data) {
-              return api.createSendAssetTansaction(data, req.service && req.service.headersToForward)
-            }).
+            then(api.createSendAssetTansaction).
             then(function(data){
               api.seedMetadata(data.metadata.sha1)
               res.json({ txHex: data.tx.toHex(), metadataSha1: data.metadata.sha1, multisigOutputs: data.multisigOutputs, coloredOutputIndexes: data.coloredOutputIndexes });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "cc-errors": "~0.0.7",
     "cc-request-id": "~0.0.3",
     "cc-transaction": "^1.1.0",
+    "cls-middleware": "^1.1.0",
+    "continuation-local-storage": "^3.1.7",
     "cors": "^2.7.1",
     "express": "4.10.4",
     "le_node": "^0.2.1",

--- a/server.js
+++ b/server.js
@@ -10,6 +10,8 @@ var piwik = require('./piwik')
 var morgan = require('morgan')
 var requestId = require('cc-request-id')
 var errors = require('cc-errors')
+var session = require('continuation-local-storage').createNamespace(config.serverName)
+var clsify = require('cls-middleware')
 
 var fs = require('fs')
 var log4js = require('log4js')
@@ -109,8 +111,13 @@ app.use(function (req, res, next) {
   next()
 })
 
+app.use(clsify(session))
+app.use(function (req, res, next) {
+  session.set('context', {req: req, res: res})
+  next()
+})
 if (config.secret) {
-  app.use(requestId({secret: config.secret, namespace: 'coloredcoinsd'}))
+  app.use(requestId({secret: config.secret, namespace: config.serverName}))
 }
 
 if (config.piwik.enabled) {


### PR DESCRIPTION
This is useful for elegantly passing correlation-id and other headers that are needed to be forwarded to other servers (currently only to block-explorer).
local-storage context is encapsulating both request and response and can be used for more needs in the future.
